### PR TITLE
致谢处页眉修复，PDF书签增强

### DIFF
--- a/cquthesis.cfg
+++ b/cquthesis.cfg
@@ -11,6 +11,7 @@
 \def\cqu@denotation@name				{主要符号对照表}
 \def\listofequationsname				{重要算式索引}
 \def\cqu@bib@name								{参考文献}
+\def\cqu@tocnameinbkmark				{目{ }录} %把目录加到书签中 Change 2016/05/16
 %中文圆括号（#1）
 \newcommand{\parenthesesthis}[1]{（#1）}
 

--- a/cquthesis.cls
+++ b/cquthesis.cls
@@ -166,6 +166,8 @@
 					 section/number		 = \Alph{section},
 					 section/name		 = {,.},
 					 subsection/number = \CTEXthesection{}\arabic{subsection},}
+	% Change on 2016/05/16 致谢的页眉不再编号
+	\setcounter{chapter}{0}	
 }
 
 % 定义页面，页眉页脚，先建立页面环境，完成分页再决定单双面打印
@@ -625,7 +627,9 @@
 % 正确输出页眉页脚
 \tocloftpagestyle{style@normal}
 % 目录和索引标题居中，包含fixhead
-\renewcommand{\cfttoctitlefont}{\cqu@fixhead\hfill\heiti\zihao{3}}
+% 把目录加到书签中 Change 2016/05/16
+\renewcommand{\cfttoctitlefont}{%
+	\phantomsection\pdfbookmark[0]{\cqu@tocnameinbkmark}{toc}\cqu@fixhead\hfill\heiti\zihao{3}}
 \renewcommand{\cftloftitlefont}{\cqu@fixhead\hfill\heiti\zihao{3}}
 \renewcommand{\cftlottitlefont}{\cqu@fixhead\hfill\heiti\zihao{3}}
 \renewcommand{\cftequtitlefont}{\cqu@fixhead\hfill\heiti\zihao{3}}
@@ -638,6 +642,7 @@
 	\renewcommand{\@cfttocstart}{\clearpage}
 	\renewcommand{\@cfttocfinish}{\clearpage}
 \fi
+
 % TODO:这个命令暂时没用上，还待观察
 %% 定义自己的章节命令\chapterstar，不编号，有目录有页眉
 \newcommand{\chapterstar}[1]{%


### PR DESCRIPTION
更新日志：
1. 致谢处的页眉现在不再和结论共享序号了（他们仍然是好兄弟~）
2. 【目录】现在已加入PDF书签。
