### PR TITLE
texlive2021中430行出现编译错误，根据siunitx文档修改适配

### DIFF
--- a/contents/analysis.tex
+++ b/contents/analysis.tex
@@ -427,7 +427,7 @@ p(y|\mathbf{x}) = \frac{p(\mathbf{x},y)}{p(\mathbf{x})}=
 \cquthesis 采用\pkg{siunitx}作为国际单位制支持宏包，以下是一些使用例子，这个包的文档写得非常不错，请在命令行里输入\texttt{texdoc siunitx}察看。
 \begin{center}
 	\num{.3e45}\\
-	\num{1.654 x 2.34 x 3.430}\\
+	\numproduct{1.654 x 2.34 x 3.430}\\
 	\si{\kilogram\metre\per\second}\\    
 	\SIlist{0.13;0.67;0.80}{\milli\metre}
 \end{center}


### PR DESCRIPTION
\num{1.654 x 2.34 x 3.430}改为\numproduct{1.654 x 2.34 x 3.430}