### PR TITLE
修复定理环境的证毕符号

### DIFF
--- a/cquthesis.dtx
+++ b/cquthesis.dtx
@@ -1390,7 +1390,7 @@
 % 定理环境中文定义在.cfg中完成
 %    \begin{macrocode}
 %<*cfg>
-\theoremsymbol{\ensuremath{\ding{110}}}
+\theoremsymbol{\ensuremath{\square}}
 \newtheorem*{proof}{证明}
 \theoremstyle{plain}
 \theoremsymbol{}


### PR DESCRIPTION
证毕符号原来用的是pifont包中的\ding{110}符号，该符号显示为实心黑方块，应该是在新版本中该符号若出现在数学环境中，则显示为字母n
去掉\ding{110}外面的\ensuremath{}命令即可
这里为了和平常的数学环境一致，改为了\square空心方块